### PR TITLE
Fix thread not closing and avoid memcpy overlap

### DIFF
--- a/Oxygen/oxygenengine/source/oxygen/application/EngineMain.cpp
+++ b/Oxygen/oxygenengine/source/oxygen/application/EngineMain.cpp
@@ -370,6 +370,7 @@ void EngineMain::shutdown()
 	RMX_LOG_INFO("System shutdown");
 	FTX::Audio->exit();
 	FTX::System->exit();
+	FTX::JobManager->~JobManager();
 
 	mInternal.mModManager.copyModSettingsToConfig();
 	Configuration::instance().saveSettings();

--- a/Oxygen/oxygenengine/source/oxygen/application/audio/AudioPlayer.cpp
+++ b/Oxygen/oxygenengine/source/oxygen/application/audio/AudioPlayer.cpp
@@ -10,7 +10,6 @@
 #include "oxygen/application/audio/AudioPlayer.h"
 #include "oxygen/application/audio/EmulationAudioSource.h"
 
-
 AudioPlayer::SoundIterator::SoundIterator(std::vector<PlayingSound>& sounds) :
 	mSounds(sounds)
 {
@@ -84,7 +83,8 @@ void AudioPlayer::startup()
 
 void AudioPlayer::shutdown()
 {
-	mAudioSourceManager.clear();
+	stopAllSounds(true);
+        mAudioSourceManager.clear();
 }
 
 void AudioPlayer::clearPlayback()

--- a/Oxygen/oxygenengine/source/oxygen/simulation/LemonScriptBindings.cpp
+++ b/Oxygen/oxygenengine/source/oxygen/simulation/LemonScriptBindings.cpp
@@ -116,7 +116,7 @@ namespace
 	{
 		uint8* destPointer = EmulatorInterface::instance().getMemoryPointer(destAddress, true, bytes);
 		uint8* sourcePointer = EmulatorInterface::instance().getMemoryPointer(sourceAddress, false, bytes);
-		memcpy(destPointer, sourcePointer, bytes);
+		memmove(destPointer, sourcePointer, bytes);
 	}
 
 	void zeroMemory(uint32 startAddress, uint32 bytes)

--- a/librmx/source/rmxmedia/JobManager.cpp
+++ b/librmx/source/rmxmedia/JobManager.cpp
@@ -142,7 +142,7 @@ namespace rmx
 		// Wait until there's at leat one job available
 		SDL_LockMutex(mConditionLock);
 		JobBase* job = getNextJobInternal();
-		while (nullptr == job)
+		while (nullptr == job && mSearchforJobs)
 		{
 			// Using a time-out for two reasons:
 			//  - to have a chance to check if "mShouldBeRunning" changed outside
@@ -219,6 +219,7 @@ namespace rmx
 
 	void JobManager::stopAllThreads()
 	{
+		mSearchforJobs = false;
 		for (JobWorkerThread* thread : mThreads)
 		{
 			thread->signalStopThread(false);

--- a/librmx/source/rmxmedia/JobManager.h
+++ b/librmx/source/rmxmedia/JobManager.h
@@ -58,6 +58,7 @@ namespace rmx
 		//     but that's probably overkill anyways if the number of active jobs is not more than a few dozens
 		std::vector<JobBase*> mJobs;
 		uint32 mNextDelayedJobTicks = 0;
+		bool mSearchforJobs = true;
 	};
 
 


### PR DESCRIPTION
Thread before would hang waiting for a next job, never closing. On a platform like the Switch this means the thread never closes and crashes happen.

I understand you asked in the README to not post PRs but I think these issues are a bit important. On the latter issue, gcc's address sanitizer reports that when entering the Normal Game menu a memcpy overlap call happens. As a sort of workaround I changed it to memmove to avoid this issue. On the former, while on most platforms not closing a thread is not as much of a problem since it gets closed on exit anyway, on platforms like homebrew on Switch they need a proper cleanup before exiting, or undefined behaviour happens. In the commits I also mixed librmx changes with Oxygen ones, if you want me to split them or edit them in any way I will. And regarding the licensing problem you mentioned in the README, as long as you credit me I don't really care :P 