### PR TITLE
fix to ceiling run crush

### DIFF
--- a/Oxygen/sonic3air/scripts/objects/shared.lemon
+++ b/Oxygen/sonic3air/scripts/objects/shared.lemon
@@ -1505,15 +1505,18 @@ function void fn01e006()
 					fn01e042()
 				}
 				else
-				{
-					// Getting crushed
-					u32 backupA0 = A0
-					A0 = A1
-					Character.Die()
-					A0 = backupA0
+				{					
+					if (objA1.value26 != 0x80)
+					{
+						// Getting crushed
+						u32 backupA0 = A0
+						A0 = A1
+						Character.Die()
+						A0 = backupA0
 
-					D6 |= (u32(1) << (D6.u16 + 15))
-					D4 = 0xfffffffe
+						D6 |= (u32(1) << (D6.u16 + 15))
+						D4 = 0xfffffffe
+					}
 				}
 				return
 			}


### PR DESCRIPTION
Adds a check for ceiling running to prevent objects killing the player when they run along the bottom of them. Bugs seen in Casino Night barrels and Hydrocity rotating pillars.