### PR TITLE
Fixes for the pillars and hand launchers in HCZ

### DIFF
--- a/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_handlauncher.lemon
+++ b/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_handlauncher.lemon
@@ -256,9 +256,7 @@ function void fn030cf8()
 			objA1.flags2a &= ~char.flag.FACING_LEFT
 			objA1.flags2a &= ~char.flag.ROLLING
 			objA1.flags2a &= ~char.flag.PUSHING
-		#if STANDLAONE
 			objA1.flags2a &= ~char.flag.IN_AIR	// Fix for wrong placement of the character if bubble-bouncing onto the hand launcher, #contributed by iCloudius
-		#endif
 			u8[A1 + 0x2e] = 1
 			objA1.position.x.u16 = objA0.position.x.u16 - 2
 			u16[A1 + 0x1c] = 0x1000

--- a/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_rotatingpillar.lemon
+++ b/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_rotatingpillar.lemon
@@ -175,17 +175,21 @@ function void fn032784()
 			--u8[A2 + 0x02]
 		}
 
+		// Prevents the game from shifting the characters over a pixel
+		// everytime the game mirrors the rotation animation
 		D0 = u8[A2 + 0x01]
-		LookupSinCos()
-		D0.u16 += 0x0100
-		D0.s16 >>= 2
-		u8[A2 + 0x03] = D0.u8
-
-		D2 = u16[A2 + 0x02]
-		D1.s32 = s32(D1.s16) * D2.s16
-		D1 = (D1 << 16) + (D1 >> 16)
-		D1.u16 += objA0.position.x.u16
-		objA1.position.x.u16 = D1.u16
+        LookupSinCos()
+        D0.u16 = (D0.s16 + 0x0100) >> 2
+        u8[A2 + 0x03] = D0.u8
+		
+        D2 = u16[A2 + 0x02]
+        D1.s32 = s32(D1.s16) * D2.s16
+        bool negative = D1.s32 < 0
+        D1.s32 = (negative) ? -D1.s32 : D1.s32
+        D1 >>= 16
+        D1.u16 = (negative) ? -D1.u16 : D1.u16
+        D1.u16 += objA0.position.x.u16
+        objA1.position.x.u16 = D1.u16
 		u8[A2 + 0x01] += 2
 		objA1.groundspeed = 0
 		D0.u16 = objA0.velocity.y

--- a/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_rotatingpillar.lemon
+++ b/Oxygen/sonic3air/scripts/objects/02_hcz/hcz_rotatingpillar.lemon
@@ -178,18 +178,18 @@ function void fn032784()
 		// Prevents the game from shifting the characters over a pixel
 		// everytime the game mirrors the rotation animation
 		D0 = u8[A2 + 0x01]
-        LookupSinCos()
-        D0.u16 = (D0.s16 + 0x0100) >> 2
-        u8[A2 + 0x03] = D0.u8
+		LookupSinCos()
+		D0.u16 = (D0.s16 + 0x0100) >> 2
+		u8[A2 + 0x03] = D0.u8
 		
-        D2 = u16[A2 + 0x02]
-        D1.s32 = s32(D1.s16) * D2.s16
-        bool negative = D1.s32 < 0
-        D1.s32 = (negative) ? -D1.s32 : D1.s32
-        D1 >>= 16
-        D1.u16 = (negative) ? -D1.u16 : D1.u16
-        D1.u16 += objA0.position.x.u16
-        objA1.position.x.u16 = D1.u16
+		D2 = u16[A2 + 0x02]
+		D1.s32 = s32(D1.s16) * D2.s16
+		bool negative = D1.s32 < 0
+		D1.s32 = (negative) ? -D1.s32 : D1.s32
+		D1 >>= 16
+		D1.u16 = (negative) ? -D1.u16 : D1.u16
+		D1.u16 += objA0.position.x.u16
+		objA1.position.x.u16 = D1.u16
 		u8[A2 + 0x01] += 2
 		objA1.groundspeed = 0
 		D0.u16 = objA0.velocity.y


### PR DESCRIPTION
This should fix the hand launcher when the character bubble bounces onto the contraption and prevents the pillars from shifting the character by 1 pixel when the character's rotation animation mirrors.