### PR TITLE
Addendum to previous pull request

### DIFF
--- a/Oxygen/sonic3air/scripts/menus/titlescreen.lemon
+++ b/Oxygen/sonic3air/scripts/menus/titlescreen.lemon
@@ -267,7 +267,7 @@ function void TitleScreen()
 	A1 = 0x00459c
 	while (true)
 	{
-		global.frame_state = 0x02
+		global.frame_state = 0x08
 		waitForNextFrame()
 
 		copyMemory(0xfffffc00, A1, 0x0e)


### PR DESCRIPTION
i noticed that you reverted the frame state in a recent commit because of a bug i didn't encounter in my testing, which is my bad. it's hard for me to test the stuff i do properly since i'm not recompiling the game, rather putting the scripts into a mod to test it and make sure it's doing what it should. i'm hoping this change does as it should this time, with it actually fading the SEGA screen from white to black without the logo disappearing or the fade not working as it should.
apologies for the accidental bug, Euka