### PR TITLE
Allow config.json from the AppData folder

### DIFF
--- a/Oxygen/oxygenengine/source/oxygen/application/EngineMain.cpp
+++ b/Oxygen/oxygenengine/source/oxygen/application/EngineMain.cpp
@@ -435,11 +435,18 @@ bool EngineMain::initConfigAndSettings(const std::wstring& argumentProjectPath)
 	config.initialization();
 
 	RMX_LOG_INFO("Loading configuration");
+	if (FTX::FileSystem->exists(config.mAppDataPath + L"config.json"))
+	{
+		config.loadConfiguration(config.mAppDataPath + L"config.json");
+	}
+	else
+	{
 #if (defined(PLATFORM_MAC) || defined(PLATFORM_IOS)) && defined(ENDUSER)
-	config.loadConfiguration(config.mGameDataPath + L"/config.json");
+		config.loadConfiguration(config.mGameDataPath + L"/config.json");
 #else
-	config.loadConfiguration(L"config.json");
+		config.loadConfiguration(L"config.json");
 #endif
+	}
 
 	// Setup a custom game profile (like S3AIR does) or load the "oxygenproject.json"
 	const bool hasCustomGameProfile = mDelegate.setupCustomGameProfile();


### PR DESCRIPTION
For platforms where the app is self contained and doesn't allow bundled data to be modified, check for config.json in the game data folder prior to falling back to the default location.