### PR TITLE
Add the Game category to the Linux setup script

### DIFF
--- a/Oxygen/sonic3air/___internal/mastering/setup_linux.sh
+++ b/Oxygen/sonic3air/___internal/mastering/setup_linux.sh
@@ -20,6 +20,7 @@ Encoding=UTF-8
 Exec=$basepath2/sonic3air_linux
 Icon=$basepath1/data/icon.png
 Terminal=false
+Categories=Game;
 EOM
 
 # Set executable flag


### PR DESCRIPTION
By default Sonic 3 A.I.R. would be in a separate category:
![image](https://github.com/user-attachments/assets/12bb1f97-51cd-4986-89f4-fd3e7cb497a5)

This PR would put it to the games category:
![image](https://github.com/user-attachments/assets/90419392-65f7-472a-af2d-63d5897cdc4a)
