### PR TITLE
Fix missing icon on Linux when running the game

### DIFF
--- a/Oxygen/sonic3air/___internal/mastering/setup_linux.sh
+++ b/Oxygen/sonic3air/___internal/mastering/setup_linux.sh
@@ -19,6 +19,7 @@ Type=Application
 Encoding=UTF-8
 Exec=$basepath2/sonic3air_linux
 Icon=$basepath1/data/icon.png
+StartupWMClass=sonic3air_linux
 Terminal=false
 Categories=Game;
 EOM


### PR DESCRIPTION
On GNOME at least (trying on Ubuntu 24.04.2), when launching the game, on the Dock, you would see the default program icon, and the bare executable name. This is how it looks like right now.

![Before](https://github.com/user-attachments/assets/b7f81897-4da6-45cd-9398-77992e592ebb)

This pull request addresses this issue by defining a `StartupWMClass` pointing to the app's wmclass in the `.desktop` file. With these changes, the game will have the correct icon and the window title name. This is how it will look like with the fix applied.

![After](https://github.com/user-attachments/assets/0e1cd67d-9eba-4579-97e0-503c57758bf4)


