### PR TITLE
Fix Pause Menu rendering in Competition Mode

### DIFF
--- a/Oxygen/sonic3air/scripts/maingame/game_pause.lemon
+++ b/Oxygen/sonic3air/scripts/maingame/game_pause.lemon
@@ -380,7 +380,9 @@ function void GamePause.DrawMenu(float time)
 	//  -> This allows for selectively clearing these sprites, texts, etc. in each frame without touching the game's rendered content
 	Renderer.resetLifetimeContext(1)
 	Renderer.setLifetimeContext(1)
-
+	
+	Renderer.setViewport(0, 0, getScreenWidth(), getScreenHeight(), 0xfeff) // Fix for Competition Mode not having the upper bar visible
+	
 	Renderer.drawSprite("pause_screen_upper", rightAnchor - 210, 0, 0, SPRITE_FLAG_PRIO | SPRITE_FLAG_NO_GLOBAL_TINT, 0xff00)
 	Renderer.drawSprite("pause_screen_lower", rightAnchor - 190, py - 8, 0, SPRITE_FLAG_PRIO | SPRITE_FLAG_NO_GLOBAL_TINT, 0xff00)
 


### PR DESCRIPTION
Because of the viewports in Competition Mode, the top bar of the Pause Menu was no longer visible.
By creating a viewport specific to the Pause Menu, it makes it so everything in the Pause Menu is guaranteed to be visible in 99% of situations.
# Before:
![before](https://github.com/user-attachments/assets/406fe5ff-324a-48d9-b19f-3f84f0936aaa)
# After:
![after](https://github.com/user-attachments/assets/bce3f6b8-6651-40d8-8804-7577583b9087)
The primary purpose is to keep the "Game Paused" text consistently visible between the normal game and Competition Mode.
Considering I haven't messed around with Viewports a whole lot, there _could_ be issues but from my testing everything seemed fine.
