### PR TITLE
Add glitch fix layout tweak for HCZ1

### DIFF
--- a/Oxygen/sonic3air/scripts/standalone/resources/level_objects/levelobjects_02_hcz.lemon
+++ b/Oxygen/sonic3air/scripts/standalone/resources/level_objects/levelobjects_02_hcz.lemon
@@ -178,6 +178,13 @@ function void LevelObjectTableBuilder.buildObjects_HCZ1()
 	LevelObjectTableBuilder.addObject(0x19b0, 0x07f0, OBJECTTABLE1_3b, 0x01, 0)
 	LevelObjectTableBuilder.addObject(0x19d8, 0x030b, OBJECTTABLE1_3e, 0x05, 0)
 	LevelObjectTableBuilder.addObject(0x19d8, 0x0335, OBJECTTABLE1_3e, 0x15, LVLOBJ_FLIP_X)
+
+	if (Game.getSetting(SETTING_FIX_GLITCHES))
+	{
+		// Push character back behind forground tile elements
+		LevelObjectTableBuilder.addObject(0x1a10, 0x06c0, OBJECTTABLE1_02, 0x41, 0)
+	}
+
 	LevelObjectTableBuilder.addObject(0x1a90, 0x07c6, OBJECTTABLE1_07, 0x24, LVLOBJ_FLIP_Y)
 	LevelObjectTableBuilder.addObject(0x1ac0, 0x036c, OBJECTTABLE1_34, 0x02, 0)
 


### PR DESCRIPTION
Hey, I hope this change is acceptable. Simply adds a new path switcher object if `SETTING_FIX_GLITCHES` is `true`.

![image](https://github.com/user-attachments/assets/bf9ba96c-43a9-4a46-bf9d-97cdff9c6214)

This prevents the issue where the player character appears in front of foreground tile elements, as demonstrated below.

![image](https://github.com/user-attachments/assets/52a8e7a8-7bf7-4569-8bdc-be7d56e57781)

Depending on the route, this state can be taken through most of the act, becoming extremely noticeable near the giant ring.

![image](https://github.com/user-attachments/assets/849dde81-c99d-4b32-adfa-cc803b99889a)
