### PR TITLE
Fix Foreground Snapping Upwards during MHZ2's Zone Transition

### DIFF
--- a/Oxygen/sonic3air/scripts/level/07_mhz/mhz2_end_cutscene.lemon
+++ b/Oxygen/sonic3air/scripts/level/07_mhz/mhz2_end_cutscene.lemon
@@ -341,6 +341,7 @@ function void fn076456()
 		return
 
 	TriggerNextZone(0x0400)		// Flying Battery Zone
+	fn054f64()
 	UnloadObject()
 
 #if STANDALONE


### PR DESCRIPTION
Since December 2025, MHZ2 zone transition causes the ground to snap upwards. I fixed this by adding an extra function call `fn054f64()` to `fn076456()`, so the ground doesn't snap upwards.

Here's how it currently looks in the base game umodded:
<img width="1200" height="672" alt="before" src="https://github.com/user-attachments/assets/a2115436-c5ff-45d6-8346-3a3eba6d9ec3" />

Now after the bugfix is applied using a mod:
<img width="1200" height="672" alt="after" src="https://github.com/user-attachments/assets/a13b6572-cb76-4f10-81f9-c86caf15aad8" />



